### PR TITLE
Fix deprecation message with dlang >= 2.079 to enable compilation with `-de`

### DIFF
--- a/source/elf/package.d
+++ b/source/elf/package.d
@@ -14,7 +14,7 @@ import std.exception;
 import std.conv : to;
 import std.typecons : Nullable;
 
-alias enforce = enforceEx!ELFException;
+alias enforce = enforce!ELFException;
 
 abstract class ELF {
 	MmFile m_file;

--- a/source/elf/sections/debugabbrev/package.d
+++ b/source/elf/sections/debugabbrev/package.d
@@ -12,7 +12,10 @@ import std.range;
 import std.conv : to;
 import elf, elf.meta;
 
-alias enforce = enforceEx!ELFException;
+static if (__VERSION__ >= 2079)
+	alias enforce = enforce!ELFException;
+else
+	alias enforce = enforceEx!ELFException;
 
 alias ULEB128 = ulong;
 alias LEB128 = long;

--- a/source/elf/sections/debugline/package.d
+++ b/source/elf/sections/debugline/package.d
@@ -14,7 +14,10 @@ import elf, elf.meta;
 
 private import elf.sections.debugline.debugline32, elf.sections.debugline.debugline64;
 
-alias enforce = enforceEx!ELFException;
+static if (__VERSION__ >= 2079)
+	alias enforce = enforce!ELFException;
+else
+	alias enforce = enforceEx!ELFException;
 
 struct DebugLine {
 	private LineProgram[] m_lps;

--- a/source/elf/sections/stringtable.d
+++ b/source/elf/sections/stringtable.d
@@ -9,7 +9,10 @@ import std.exception;
 import std.conv : to;
 import elf;
 
-alias enforce = enforceEx!ELFException;
+static if (__VERSION__ >= 2079)
+	alias enforce = enforce!ELFException;
+else
+	alias enforce = enforceEx!ELFException;
 
 struct StringTable {
 	private ELFSection m_section;

--- a/source/elf/sections/symboltable.d
+++ b/source/elf/sections/symboltable.d
@@ -9,7 +9,11 @@ import std.exception;
 import std.conv : to;
 import elf, elf.low, elf.low32, elf.low64, elf.meta;
 
-alias enforce = enforceEx!ELFException;
+static if (__VERSION__ >= 2079)
+	alias enforce = enforce!ELFException;
+else
+	alias enforce = enforceEx!ELFException;
+
 
 struct SymbolTable {
 	private SymbolTableImpl m_impl;


### PR DESCRIPTION
@yazd Thanks for quick review.

Reference: https://dlang.org/changelog/2.079.0.html#std-exception-enforce